### PR TITLE
fix dropout = 1.0 issue. If dropout = 1.0, it should not run dropout …

### DIFF
--- a/tf_unet/layers.py
+++ b/tf_unet/layers.py
@@ -36,7 +36,10 @@ def conv2d(x, W, b, keep_prob_):
     with tf.name_scope("conv2d"):
         conv_2d = tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding='VALID')
         conv_2d_b = tf.nn.bias_add(conv_2d, b)
-        return tf.nn.dropout(conv_2d_b, keep_prob_)
+        if keep_prob_ < 1.0:
+            return tf.nn.dropout(conv_2d_b, keep_prob_)
+        else:
+            return conv_2d_b
 
 def deconv2d(x, W,stride):
     with tf.name_scope("deconv2d"):


### PR DESCRIPTION
Python Dropout op uses the following code to check keep_prob value:
if tensor_util.constant_value(keep_prob) == 1: return x
If keep_prob is placeholder, tensor_util.constant_value(keep_prob) will return None, if statement will always be false.